### PR TITLE
TRD-1463 : Drop /basket/placeAtMarket and MKT/SL-M from non-GTT write…

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ setBaseUrl("https://tradeapi.samco.in");
  *  <a href="#modifyBasketOrder">ModifyBasketOrder</a> &nbsp;<sup>NEW in 3.2.0</sup>
  *  <a href="#deleteBasketOrder">DeleteBasketOrder</a> &nbsp;<sup>NEW in 3.2.0</sup>
  *  <a href="#executeBasket">ExecuteBasketOrder</a> &nbsp;<sup>NEW in 3.2.0</sup>
- *  <a href="#placeAtMarket">PlaceAtMarket</a> &nbsp;<sup>NEW in 3.2.0</sup>
  *  <a href="#basketSquareOff">BasketSquareOff</a> &nbsp;<sup>NEW in 3.2.0</sup>
  *  <a href="#rearrangeBasket">RearrangeBasketOrder</a> &nbsp;<sup>NEW in 3.2.0</sup>
  *  <a href="#basketSpanCalculator">BasketSpanCalculator</a> &nbsp;<sup>NEW in 3.2.0</sup>
@@ -1051,7 +1050,7 @@ const response = await ordersApi.bulkOrder(sessionToken, {
 
 ###  <h3 id="modify_order">Modify Order:</h3>
 
-   User would be able to modify some attributes of an order as long as it is with open/pending status in system. For modification order identifier is mandatory. With order identifier you need to send the optional parameter(s) which needs to be modified. In case the optional parameters aren't sent, the default will be considered from the original order. Modifiable attributes include quantity, Order Type (L,MKT, SL,SL-M). This API cannot be used for modifying attributes of an executed/rejected/cancelled order. Only the attribute that needs to be modified should be sent in the request alongwith the Order Identifier.
+   User would be able to modify some attributes of an order as long as it is with open/pending status in system. For modification order identifier is mandatory. With order identifier you need to send the optional parameter(s) which needs to be modified. In case the optional parameters aren't sent, the default will be considered from the original order. Modifiable attributes include quantity, Order Type (L, SL). This API cannot be used for modifying attributes of an executed/rejected/cancelled order. Only the attribute that needs to be modified should be sent in the request alongwith the Order Identifier.
 
 #### Parameters:
 
@@ -2107,16 +2106,6 @@ Executes every order in the basket using its configured `orderType` / `price` / 
 const resp = await new BasketApi().executeBasketOrder(sessionToken, {
   basketId,
 });
-```
-
-
-### <h3 id="placeAtMarket">PlaceAtMarket (v3.2.0):</h3>
-
-Executes every order in the basket at market price (overriding individual order types).
-
-#### Sample PlaceAtMarket Request:
-```typescript
-const resp = await new BasketApi().placeAtMarket(sessionToken, { basketId });
 ```
 
 

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,7 +18,7 @@
     "quick-start": "ts-node -r dotenv/config quickStart.ts"
   },
   "dependencies": {
-    "samco-bridge-node": "^3.2.0",
+    "samco-bridge-node": "^3.2.1",
     "ws": "^8.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
…-side docs

Aligns the Node.js SDK README and samples with ta-api-docs TRD-1463 (mirror of ta-java-sdk commit 5e70c58): /basket/placeAtMarket is removed, and the MKT / SL-M order types are dropped from the non-GTT write-side surface (Modify Order). GTT / GTTOCO sections, the OrderBook/TradeBook broad-read response samples, and the auth-response orderTypeList array are left intact per the docs' explicit carve-out.

- README: remove placeAtMarket TOC entry and section
- README: trim Modify Order modifiable Order Type list to (L, SL)
- samples/package.json: bump samco-bridge-node dependency to ^3.2.1