### PR TITLE
TRD-1467 : Append "\n" to streaming subscribe/unsubscribe frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -2232,7 +2232,7 @@ const subscribe = {
   },
 };
 
-ws.on("open", () => ws.send(JSON.stringify(subscribe)));
+ws.on("open", () => ws.send(JSON.stringify(subscribe) + "\n"));
 ws.on("message", (msg) => console.log("Tick ::", msg.toString()));
 ws.on("error", (err) => console.error("WS error:", err));
 ws.on("close", (code) => console.log("Connection closed:", code));
@@ -2242,7 +2242,7 @@ const unsubscribe = {
   ...subscribe,
   request: { ...subscribe.request, request_type: "unsubscribe" },
 };
-ws.send(JSON.stringify(unsubscribe));
+ws.send(JSON.stringify(unsubscribe) + "\n");
 ws.close(1000, "client shutdown");
 ```
 

--- a/samples/streamingMarketData.ts
+++ b/samples/streamingMarketData.ts
@@ -59,7 +59,7 @@ export function streamMarketData(
 
   ws.on("open", () => {
     console.log("Connected to", STREAM_URL);
-    ws.send(JSON.stringify(buildFrame(symbols, "subscribe")));
+    ws.send(JSON.stringify(buildFrame(symbols, "subscribe")) + "\n");
     console.log("Subscribed to", symbols.join(", "));
   });
 
@@ -74,7 +74,7 @@ export function streamMarketData(
 
 export function closeMarketDataStream(ws: WebSocket, symbols: string[]): void {
   if (ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")));
+    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")) + "\n");
     ws.close(1000, "client shutdown");
   }
 }

--- a/samples/streamingQuote.ts
+++ b/samples/streamingQuote.ts
@@ -56,7 +56,7 @@ export function streamQuotes(sessionToken: string, symbols: string[]): WebSocket
 
   ws.on("open", () => {
     console.log("Connected to", STREAM_URL);
-    const frame = JSON.stringify(buildFrame(symbols, "subscribe"));
+    const frame = JSON.stringify(buildFrame(symbols, "subscribe")) + "\n";
     console.log("Subscribe ->", frame);
     ws.send(frame);
   });
@@ -80,7 +80,7 @@ export function streamQuotes(sessionToken: string, symbols: string[]): WebSocket
 // Graceful unsubscribe-then-close helper. Safe to call multiple times.
 export function closeQuoteStream(ws: WebSocket, symbols: string[]): void {
   if (ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")));
+    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")) + "\n");
     ws.close(1000, "client shutdown");
   }
 }


### PR DESCRIPTION
Mirrors the Java SDK fix (samco-bridge-java c230c71): the stream server requires a newline-terminated frame, otherwise subscribe and unsubscribe payloads are dropped silently and no quote/market-data ticks are delivered. Appends "\n" to every JSON.stringify(...) value passed to ws.send(...) in the two streaming samples and the README sample block.