### PR TITLE
TRD-1467 : Switch streaming samples and README to samco-bridge-node v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2205,46 +2205,58 @@ const resp = await new ContractAnalyserApi().analyse(sessionToken, {
 ```
 
 
-### <h3 id="streaming">Streaming (WebSocket — v3.2.0):</h3>
+### <h3 id="streaming">Streaming (WebSocket — v3.2.0, SDK in v3.2.2):</h3>
 
 Real-time **quote** and **market-depth** streams are exposed over a WebSocket at `wss://stream.samco.in`. The connection authenticates via the `x-session-token` header (the JWT returned by <a href="#sessiontoken">GenerateSessionToken</a>).
 
 A symbol is encoded as `"<listingId>_<exchange>"` (for example `"3045_NSE"`), taken from `ScripMaster.csv`.
 
-The Node samples in [`samples/streamingQuote.ts`](./samples/streamingQuote.ts) and [`samples/streamingMarketData.ts`](./samples/streamingMarketData.ts) use the `ws` package directly.
+Starting in **v3.2.2** the SDK ships a typed `StreamingClient` (built on `ws`) that handles the subscribe / unsubscribe envelope, header-based auth, and dispatch to typed listener callbacks. The Node samples in [`samples/streamingQuote.ts`](./samples/streamingQuote.ts) and [`samples/streamingMarketData.ts`](./samples/streamingMarketData.ts) demonstrate both stream types.
 
-#### Sample Streaming Usage:
+#### Public API:
+
 ```typescript
-import WebSocket from "ws";
+import {
+  StreamingClient,
+  StreamingListener,
+  QuoteTick,
+  DepthTick,
+  symbolRef,
+} from "samco-bridge-node";
 
-const STREAM_URL = "wss://stream.samco.in";
-
-const ws = new WebSocket(STREAM_URL, {
-  headers: { "x-session-token": sessionToken },
-});
-
-const subscribe = {
-  request: {
-    streaming_type: "quote", // or "quote2" for 5-level market depth
-    data: { symbols: [{ symbol: "3045_NSE" }] },
-    request_type: "subscribe",
-    response_format: "json",
-  },
+// All callbacks are optional — override only the ones you care about.
+const listener: StreamingListener = {
+  onOpen: () => console.log("open"),
+  onQuote: (tick: QuoteTick) => console.log("ltp", tick.symbol, tick.lastTradedPrice),
+  onDepth: (tick: DepthTick) => console.log("depth", tick.symbol, tick.bid, tick.ask),
+  onMessage: (text) => console.log("raw", text), // frames that don't match a known shape
+  onError: (err) => console.error(err),
+  onClosed: (code, reason) => console.log("closed", code, reason),
 };
 
-ws.on("open", () => ws.send(JSON.stringify(subscribe) + "\n"));
-ws.on("message", (msg) => console.log("Tick ::", msg.toString()));
-ws.on("error", (err) => console.error("WS error:", err));
-ws.on("close", (code) => console.log("Connection closed:", code));
+const client = new StreamingClient(listener);
+await client.connect(sessionToken);                      // wss://stream.samco.in by default
 
-// Graceful shutdown — always unsubscribe before closing in production code.
-const unsubscribe = {
-  ...subscribe,
-  request: { ...subscribe.request, request_type: "unsubscribe" },
-};
-ws.send(JSON.stringify(unsubscribe) + "\n");
-ws.close(1000, "client shutdown");
+client.subscribeQuote([symbolRef("3045_NSE")]);          // streaming_type=quote
+client.subscribeMarketDepth([symbolRef("532826_BSE")]);  // streaming_type=quote2 (5-level depth)
+
+// Always unsubscribe before closing in production code.
+client.unsubscribeQuote([symbolRef("3045_NSE")]);
+client.close();
 ```
+
+#### Constructor options:
+
+```typescript
+new StreamingClient(listener);                          // default 10s connect timeout
+new StreamingClient(listener, { handshakeTimeout: 5000 });  // any ws.ClientOptions
+```
+
+`StreamingClient.connect(sessionToken, url?)` returns a `Promise<void>` that resolves once the WebSocket handshake completes; the second argument lets you point at a non-default endpoint (e.g. for testing). To override the default streaming URL globally, call `setStreamingUrl("wss://...")` from `samco-bridge-node` before constructing the client.
+
+#### Tick payload:
+
+`QuoteTick` exposes the well-known fields (`symbol`, `exchange`, `lastTradedPrice`, `openPrice`, `highPrice`, `lowPrice`, `closePrice`, `volume`, `tickTime`) and a `raw: Record<string, unknown>` passthrough for any additional payload fields. `DepthTick` exposes `bid` / `ask` as 5-level arrays plus `raw`.
 
 
 ### <h3 id="logout">Logout:</h3>

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,9 +1,10 @@
 # SAMCO Trade API v3.2 — Node.js samples
 
 Runnable TypeScript samples for the v3.2 endpoints documented in
-[`ta-api-docs`](https://docs-tradeapi.samco.in). Most samples are plain
-`fetch` / `ws` (no SDK dependency) so they read 1:1 against the docs;
-`sampleClient.ts` is the same flow expressed through `samco-bridge-node`.
+[`ta-api-docs`](https://docs-tradeapi.samco.in). REST samples are plain
+`fetch` (no SDK dependency) so they read 1:1 against the docs;
+streaming samples use the `StreamingClient` shipped in `samco-bridge-node`
+**v3.2.2+**. `sampleClient.ts` is the same flow expressed through the SDK.
 
 ## Install
 

--- a/samples/package.json
+++ b/samples/package.json
@@ -18,12 +18,10 @@
     "quick-start": "ts-node -r dotenv/config quickStart.ts"
   },
   "dependencies": {
-    "samco-bridge-node": "^3.2.1",
-    "ws": "^8.18.0"
+    "samco-bridge-node": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "@types/ws": "^8.5.12",
     "dotenv": "^16.4.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.0"

--- a/samples/quickStart.ts
+++ b/samples/quickStart.ts
@@ -9,7 +9,7 @@
  *                                  (each runs ~60s then auto-shuts down).
  */
 
-import WebSocket from "ws";
+import { StreamingClient } from "samco-bridge-node";
 import { getHoldings } from "./getHoldings";
 import { getOrderStatus } from "./getOrderStatus";
 import { getPositions } from "./getPositions";
@@ -63,47 +63,28 @@ async function runStep(title: string, step: () => Promise<void>): Promise<void> 
 
 async function runStream(
   title: string,
-  open: () => WebSocket,
-  close: (ws: WebSocket) => void,
+  open: () => Promise<StreamingClient>,
+  close: (client: StreamingClient) => void,
   durationMs: number
 ): Promise<void> {
   section(title);
   console.log(`[${title}] streaming for ${durationMs / 1000}s …`);
-  await new Promise<void>((resolve) => {
-    let ws: WebSocket;
-    try {
-      ws = open();
-    } catch (err) {
-      const e = err as Error;
-      console.log(`[${title}] failed: ${e.name}: ${e.message}`);
-      resolve();
-      return;
-    }
-    let received = 0;
-    ws.on("message", () => {
-      received++;
-    });
 
-    let settled = false;
-    const finish = () => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      console.log(
-        `[${title}] closed - ${received} message(s) received in ${durationMs / 1000}s.`
-      );
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      console.log(
-        `[${title}] ${durationMs / 1000}s elapsed - unsubscribing and closing.`
-      );
-      close(ws);
-      setTimeout(finish, 1500); // safety net if server never echoes close
-    }, durationMs);
-    ws.on("close", finish);
-    ws.on("error", finish);
-  });
+  let client: StreamingClient | null = null;
+  try {
+    client = await open();
+  } catch (err) {
+    const e = err as Error;
+    console.log(`[${title}] failed to open: ${e.name}: ${e.message}`);
+    return;
+  }
+
+  await new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+  console.log(
+    `[${title}] ${durationMs / 1000}s elapsed - unsubscribing and closing.`
+  );
+  close(client);
+  await new Promise<void>((resolve) => setTimeout(resolve, 500));
 }
 
 async function main(): Promise<void> {

--- a/samples/streamingMarketData.ts
+++ b/samples/streamingMarketData.ts
@@ -1,5 +1,5 @@
 /**
- * g. Streaming Market Data — WebSocket (5-level market depth)
+ * g. Streaming Market Data — WebSocket (5-level market depth via samco-bridge-node SDK)
  *
  * Source: ta-api-docs/streaming/streaming-market-data.md
  *
@@ -9,77 +9,59 @@
  * Same socket as the quote stream, but `streaming_type` is `"quote2"` and
  * frames carry 5 levels of bid/ask market depth instead of a single quote.
  *
- * Subscribe frame:
- *   { request: { streaming_type: "quote2",
- *                data: { symbols: [{ symbol: "3880_NSE" }, ...] },
- *                request_type: "subscribe",
- *                response_format: "json" } }
- *
- * Runtime: Node 22+ with `npm i ws`.
+ * v3.2.2 of samco-bridge-node exposes this via `StreamingClient.subscribeMarketDepth`,
+ * dispatching frames to the `onDepth` listener callback.
  *
  * Run:
  *   export SAMCO_SESSION_TOKEN=<JWT>
  *   npx ts-node samples/streamingMarketData.ts
  */
 
-import WebSocket from "ws";
+import {
+  StreamingClient,
+  StreamingListener,
+  DepthTick,
+  symbolRef,
+} from "samco-bridge-node";
 
-const STREAM_URL = "wss://stream.samco.in";
-
-interface MarketDataFrame {
-  request: {
-    streaming_type: "quote2";
-    data: { symbols: { symbol: string }[] };
-    request_type: "subscribe" | "unsubscribe";
-    response_format: "json";
-  };
-}
-
-function buildFrame(
-  symbols: string[],
-  action: "subscribe" | "unsubscribe"
-): MarketDataFrame {
-  return {
-    request: {
-      streaming_type: "quote2",
-      data: { symbols: symbols.map((s) => ({ symbol: s })) },
-      request_type: action,
-      response_format: "json",
-    },
-  };
-}
-
-export function streamMarketData(
+export async function streamMarketData(
   sessionToken: string,
   symbols: string[]
-): WebSocket {
-  const ws = new WebSocket(STREAM_URL, {
-    headers: { "x-session-token": sessionToken },
-  });
+): Promise<StreamingClient> {
+  const refs = symbols.map(symbolRef);
 
-  ws.on("open", () => {
-    console.log("Connected to", STREAM_URL);
-    ws.send(JSON.stringify(buildFrame(symbols, "subscribe")) + "\n");
-    console.log("Subscribed to", symbols.join(", "));
-  });
+  const listener: StreamingListener = {
+    onOpen: () => {
+      console.log("Connected to streaming feed");
+      console.log("Subscribed to", symbols.join(", "));
+    },
+    onDepth: (tick: DepthTick) => {
+      console.log("MarketData ::", JSON.stringify(tick.raw ?? tick));
+    },
+    onMessage: (text) => console.log("Raw ::", text),
+    onError: (err) => console.error("WS error:", err),
+    onClosed: (code) => console.log("Connection closed:", code),
+  };
 
-  ws.on("message", (msg: WebSocket.RawData) => {
-    console.log("MarketData ::", msg.toString());
-  });
-
-  ws.on("error", (err: Error) => console.error("WS error:", err));
-  ws.on("close", (code: number) => console.log("Connection closed:", code));
-  return ws;
+  const client = new StreamingClient(listener);
+  await client.connect(sessionToken);
+  client.subscribeMarketDepth(refs);
+  return client;
 }
 
-export function closeMarketDataStream(ws: WebSocket, symbols: string[]): void {
-  if (ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")) + "\n");
-    ws.close(1000, "client shutdown");
+export function closeMarketDataStream(
+  client: StreamingClient,
+  symbols: string[]
+): void {
+  try {
+    client.unsubscribeMarketDepth(symbols.map(symbolRef));
+  } catch {
+    // already disconnected
   }
+  client.close();
 }
 
-function main() {
+async function main() {
   const sessionToken = process.env.SAMCO_SESSION_TOKEN;
   if (!sessionToken) {
     console.error("Set SAMCO_SESSION_TOKEN in samples/.env.");
@@ -88,10 +70,10 @@ function main() {
 
   // `<listingId>_<exchange>` from ScripMaster.csv (per the doc's sample).
   const symbols = ["1594_NSE"];
-  const ws = streamMarketData(sessionToken, symbols);
+  const client = await streamMarketData(sessionToken, symbols);
 
   const shutdown = () => {
-    closeMarketDataStream(ws, symbols);
+    closeMarketDataStream(client, symbols);
     setTimeout(() => process.exit(0), 500);
   };
   process.on("SIGINT", shutdown);
@@ -99,5 +81,8 @@ function main() {
 }
 
 if (require.main === module) {
-  main();
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
 }

--- a/samples/streamingQuote.ts
+++ b/samples/streamingQuote.ts
@@ -1,91 +1,68 @@
 /**
- * f. Streaming Quote Data — WebSocket
+ * f. Streaming Quote Data — WebSocket (via samco-bridge-node SDK)
  *
  * Source: ta-api-docs/streaming/streaming-quote-data.md
  *
  * Endpoint: wss://stream.samco.in
  * Auth    : `x-session-token` header (JWT from POST /session/token).
  *
- * Subscribe frame shape:
- *   { request: { streaming_type: "quote",
- *                data: { symbols: [{ symbol: "<listingId>_<exch>" }] },
- *                request_type: "subscribe",
- *                response_format: "json" } }
- *
- * The same frame with `request_type: "unsubscribe"` stops a stream — always
- * unsubscribe before closing in production code.
- *
- * Runtime: Node 22+ with the `ws` package — `npm i ws`.
+ * v3.2.2 of samco-bridge-node ships a typed `StreamingClient` that wraps the
+ * subscribe / unsubscribe envelope and dispatches `quote` ticks to onQuote
+ * and `quote2` (depth) ticks to onDepth. Symbol format remains
+ * `"<listingId>_<exchange>"` (e.g. `"3045_NSE"`) from ScripMaster.csv.
  *
  * Run:
  *   export SAMCO_SESSION_TOKEN=<JWT>
  *   npx ts-node samples/streamingQuote.ts
  */
 
-import WebSocket from "ws";
+import {
+  StreamingClient,
+  StreamingListener,
+  QuoteTick,
+  symbolRef,
+} from "samco-bridge-node";
 
-const STREAM_URL = "wss://stream.samco.in";
+export async function streamQuotes(
+  sessionToken: string,
+  symbols: string[]
+): Promise<StreamingClient> {
+  const refs = symbols.map(symbolRef);
 
-interface SubscribeFrame {
-  request: {
-    streaming_type: "quote";
-    data: { symbols: { symbol: string }[] };
-    request_type: "subscribe" | "unsubscribe";
-    response_format: "json";
-  };
-}
-
-function buildFrame(
-  symbols: string[],
-  action: "subscribe" | "unsubscribe"
-): SubscribeFrame {
-  return {
-    request: {
-      streaming_type: "quote",
-      data: { symbols: symbols.map((s) => ({ symbol: s })) },
-      request_type: action,
-      response_format: "json",
+  const listener: StreamingListener = {
+    onOpen: () => {
+      console.log("Connected to streaming feed");
+      console.log("Subscribe ->", symbols.join(", "));
     },
+    onQuote: (tick: QuoteTick) => {
+      console.log("Quote ::", JSON.stringify(tick.raw ?? tick));
+    },
+    onMessage: (text) => console.log("Raw ::", text),
+    onError: (err) => console.error("WS error:", err),
+    onClosed: (code, reason) =>
+      console.log("Connection closed:", code, reason),
   };
-}
 
-export function streamQuotes(sessionToken: string, symbols: string[]): WebSocket {
-  const ws = new WebSocket(STREAM_URL, {
-    headers: { "x-session-token": sessionToken },
-  });
-
-  ws.on("open", () => {
-    console.log("Connected to", STREAM_URL);
-    const frame = JSON.stringify(buildFrame(symbols, "subscribe")) + "\n";
-    console.log("Subscribe ->", frame);
-    ws.send(frame);
-  });
-
-  ws.on("message", (msg: WebSocket.RawData) => {
-    console.log("Quote ::", msg.toString());
-  });
-
-  ws.on("unexpected-response", (_req, res) =>
-    console.error("WS unexpected-response:", res.statusCode, res.statusMessage)
-  );
-  ws.on("ping", () => console.log("WS ping <-"));
-  ws.on("pong", () => console.log("WS pong <-"));
-  ws.on("error", (err: Error) => console.error("WS error:", err));
-  ws.on("close", (code: number, reason: Buffer) =>
-    console.log("Connection closed:", code, reason.toString())
-  );
-  return ws;
+  const client = new StreamingClient(listener);
+  await client.connect(sessionToken);
+  client.subscribeQuote(refs);
+  return client;
 }
 
 // Graceful unsubscribe-then-close helper. Safe to call multiple times.
-export function closeQuoteStream(ws: WebSocket, symbols: string[]): void {
-  if (ws.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify(buildFrame(symbols, "unsubscribe")) + "\n");
-    ws.close(1000, "client shutdown");
+export function closeQuoteStream(
+  client: StreamingClient,
+  symbols: string[]
+): void {
+  try {
+    client.unsubscribeQuote(symbols.map(symbolRef));
+  } catch {
+    // already disconnected
   }
+  client.close();
 }
 
-function main() {
+async function main() {
   const sessionToken = process.env.SAMCO_SESSION_TOKEN;
   if (!sessionToken) {
     console.error("Set SAMCO_SESSION_TOKEN in samples/.env.");
@@ -94,10 +71,10 @@ function main() {
 
   // Symbols use the `<listingId>_<exchange>` form from ScripMaster.csv.
   const symbols = ["11536_NSE"];
-  const ws = streamQuotes(sessionToken, symbols);
+  const client = await streamQuotes(sessionToken, symbols);
 
   const shutdown = () => {
-    closeQuoteStream(ws, symbols);
+    closeQuoteStream(client, symbols);
     setTimeout(() => process.exit(0), 500);
   };
   process.on("SIGINT", shutdown);
@@ -105,5 +82,8 @@ function main() {
 }
 
 if (require.main === module) {
-  main();
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
…3.2.2 StreamingClient

Now that samco-bridge-node v3.2.2 ships a typed `StreamingClient`, the streaming samples no longer need to talk to `wss://stream.samco.in` directly with raw `ws`.

 - `samples/streamingQuote.ts` — rewritten to use `StreamingClient` + `subscribeQuote` + `symbolRef`; returns a `StreamingClient` instead of a raw `WebSocket`.

 - `samples/streamingMarketData.ts` — same shape but `subscribeMarketDepth`
   + `onDepth`.

 - `samples/quickStart.ts` — `runStream` now takes a `() => Promise<StreamingClient>` and a `close` callback; the `ws` import is dropped.

 - `samples/package.json` — bump `samco-bridge-node` to `^3.2.2`; drop `ws` and `@types/ws` (provided transitively by the SDK).

 - `samples/README.md` — note that streaming samples now use the SDK.

 - `README.md` (root) — rewrite the `<h3 id="streaming">` block to show the new `StreamingClient` / `StreamingListener` / `QuoteTick` / `DepthTick` / `symbolRef` surface, constructor options, and a tick-payload field reference.

Verified end-to-end via `npm run quick-start` with `SAMCO_RUN_STREAMING=true SAMCO_RUN_PLACE_ORDER=false`: REST flow plus both quote and market-depth streams connect, decode, and close cleanly.